### PR TITLE
fix: Fix adding issues to sprints and dryrun flag usage.

### DIFF
--- a/src/jirablueprint/jirablueprint.py
+++ b/src/jirablueprint/jirablueprint.py
@@ -182,7 +182,7 @@ class JiraBlueprint:
                 del finalfields[sprintfield]
 
                 def map_sprint(item):
-                    sprintdict = self.get_sprint_dict(item["board"])[item["id"]].name
+                    sprintdict = self.get_sprint_dict(item["board"])
                     return sprintdict[item["id"]].name
 
                 sprintinfo = ",".join(map(map_sprint, addsprints))
@@ -217,6 +217,6 @@ class JiraBlueprint:
             if "children" in issuemeta:
                 self.console.indent()
                 self.process_issues(
-                    issuemeta["children"], args, issue.key if issue else None, dry
+                    issuemeta["children"], args, issue.key if issue else None, assignee, dry
                 )
                 self.console.dedent()


### PR DESCRIPTION
Adding issues to sprints incorrectly duplicated sprint map retrieval in map creation and return calls. Creating issues with the dryrun flag passed dryrun flag as assignee in method call. This change fixes both bugs.